### PR TITLE
Add function to reseed simplex

### DIFF
--- a/Source/SimplexNoise/Private/SimplexNoiseBPLibrary.cpp
+++ b/Source/SimplexNoise/Private/SimplexNoiseBPLibrary.cpp
@@ -61,6 +61,23 @@ unsigned char USimplexNoiseBPLibrary::perm[512] = { 151,160,137,91,90,15,
 138,236,205,93,222,114,67,29,24,72,243,141,128,195,78,66,215,61,156,180
 };
 
+void USimplexNoiseBPLibrary::setNoiseSeed(const int32& newSeed)
+{
+	TArray<bool> availableSeeds;
+	availableSeeds.Init(true, 256);
+	FMath::RandInit(newSeed);
+	for (uint16 it = 0; it < 256;++it)
+	{
+		uint8 nextNum;
+		do 
+		{
+			nextNum = FMath::RandRange(0, 255);
+		} while (!availableSeeds[nextNum]);
+		USimplexNoiseBPLibrary::perm[it] = (unsigned char)nextNum;
+		USimplexNoiseBPLibrary::perm[it+256] = (unsigned char)nextNum;
+	}
+}
+
 static unsigned char simplex[64][4] = {
 	{ 0,1,2,3 },{ 0,1,3,2 },{ 0,0,0,0 },{ 0,2,3,1 },{ 0,0,0,0 },{ 0,0,0,0 },{ 0,0,0,0 },{ 1,2,3,0 },
 	{ 0,2,1,3 },{ 0,0,0,0 },{ 0,3,1,2 },{ 0,3,2,1 },{ 0,0,0,0 },{ 0,0,0,0 },{ 0,0,0,0 },{ 1,3,2,0 },

--- a/Source/SimplexNoise/Public/SimplexNoiseBPLibrary.h
+++ b/Source/SimplexNoise/Public/SimplexNoiseBPLibrary.h
@@ -39,6 +39,9 @@ private:
 public:
 
 	UFUNCTION(BlueprintCallable, Category = "SimplexNoise")
+		static void setNoiseSeed(const int32& newSeed);
+
+	UFUNCTION(BlueprintCallable, Category = "SimplexNoise")
 		static float SimplexNoise1D(float x);
 
 	UFUNCTION(BlueprintCallable, Category = "SimplexNoise")


### PR DESCRIPTION
Thank you so much for taking the time to implement this library, it saved me a ton of time today.

I added a function to reseed the static permutation table and thought that you and other users of the library would find it useful. By changing the permutation seed you can get a different noise sample for a given range of numbers without having to gymnastics on the numbers you're entering into the function.
