### PR TITLE
Update SimplexNoise.Build.cs

### DIFF
--- a/Source/SimplexNoise/SimplexNoise.Build.cs
+++ b/Source/SimplexNoise/SimplexNoise.Build.cs
@@ -7,7 +7,8 @@ using UnrealBuildTool;
 
 public class SimplexNoise : ModuleRules
 {
-	public SimplexNoise(TargetInfo Target)
+	public SimplexNoise(ReadOnlyTargetRules Target) : base(Target)	//4.16+ Module Constructor
+	//public SimplexNoise(TargetInfo Target) //4.15 Module Constructor
 	{
 		//Private Paths
         PrivateIncludePaths.AddRange(new string[] { 


### PR DESCRIPTION
change obsolete module constructor rules to newer parameters. 4.16+
commented out 4.15 constructor for those who might still want it for that version.